### PR TITLE
_nav.scss: pokestop scrollbar fix

### DIFF
--- a/static/sass/layout/_nav.scss
+++ b/static/sass/layout/_nav.scss
@@ -107,6 +107,7 @@
 			padding-right: 0.5em;
 			padding-bottom: 0.5em;
 			padding-left: 0.5em;
+			overflow-x: hidden !important;
 		}
 		.ui-state-active,
 		.onoffswitch-checkbox:checked+.onoffswitch-label {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fixed a scrollbar displaying after toggling "pokestop" on.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

